### PR TITLE
Bumps electron to 0.36.10 and fixes typo in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/resin-io-projects/electron-rpi-quick-start && cd el
 
 Add your resin.io applications remote endpoint
 ```
-git add remote resin <username>@git.resin.io:<username>/<app-name>.git
+git remote add resin <username>@git.resin.io:<username>/<app-name>.git
 ```
 
 Make sure your device has a screen attached. If you are using the Raspberry Pi 7” Touchscreen Display, follow the instructions [here](http://docs.resin.io/#/pages/hardware/i2c-and-spi.md#raspberry-pi-7-touchscreen-display).

--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/index.html');
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools();

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/atom/electron-quick-start#readme",
   "devDependencies": {
-    "electron-prebuilt": "^0.34.0"
+    "electron-prebuilt": "^0.36.10"
   },
   "dependencies": {
   }


### PR DESCRIPTION
Also updates to loadURL method introduced in [0.36.5](https://github.com/atom/electron/releases/tag/v0.36.5)
